### PR TITLE
upgrade gems version

### DIFF
--- a/package/Gemfile
+++ b/package/Gemfile
@@ -1,17 +1,21 @@
 source 'https://rubygems.org'
 
-gem 'fluentd', '~>1.3.3'
+gem 'cool.io'
+gem 'oj'
+gem 'json'
+
+gem 'fluentd'
 
 # Input / Output plugins:
-gem 'fluent-plugin-elasticsearch', '~>2.12.3'
-gem 'fluent-plugin-prometheus', '~>1.2.1'
-gem 'fluent-plugin-splunk-enterprise', '~> 0.9.1'
-gem 'fluent-plugin-kafka', '~> 0.8.1'
+gem 'fluent-plugin-elasticsearch'
+gem 'fluent-plugin-prometheus'
+gem 'fluent-plugin-splunk-enterprise'
+gem 'fluent-plugin-kafka'
 gem 'fluent-plugin-kubernetes_metadata_filter', '~>2.0.0'
-gem 'fluent-plugin-remote_syslog_tls', '~> 1.0.2'
+gem 'fluent-plugin-remote_syslog_tls'
 
 # filter plugins
-gem 'fluent-plugin-rewrite-tag-filter', '~> 2.1.1'
+gem 'fluent-plugin-rewrite-tag-filter'
 
 # third party
-gem 'zookeeper', '~> 1.4.11'
+gem 'zookeeper'

--- a/package/Gemfile.lock
+++ b/package/Gemfile.lock
@@ -1,58 +1,58 @@
 GEM
-  remote: https://api.rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    activesupport (5.2.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    concurrent-ruby (1.1.4)
-    cool.io (1.5.3)
+    concurrent-ruby (1.1.5)
+    cool.io (1.5.4)
     dig_rb (1.0.1)
     digest-crc (0.4.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (6.1.0)
-      elasticsearch-api (= 6.1.0)
-      elasticsearch-transport (= 6.1.0)
-    elasticsearch-api (6.1.0)
+    elasticsearch (7.2.0)
+      elasticsearch-api (= 7.2.0)
+      elasticsearch-transport (= 7.2.0)
+    elasticsearch-api (7.2.0)
       multi_json
-    elasticsearch-transport (6.1.0)
+    elasticsearch-transport (7.2.0)
       faraday
       multi_json
-    excon (0.62.0)
+    excon (0.65.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     fluent-config-regexp-type (1.0.0)
       fluentd (> 1.0.0, < 2)
-    fluent-plugin-elasticsearch (2.12.5)
+    fluent-plugin-elasticsearch (3.5.2)
       elasticsearch
       excon
-      fluentd (>= 0.14.20)
-    fluent-plugin-kafka (0.8.4)
+      fluentd (>= 0.14.22)
+    fluent-plugin-kafka (0.11.0)
       fluentd (>= 0.10.58, < 2)
       ltsv
-      ruby-kafka (>= 0.7.1, < 0.8.0)
+      ruby-kafka (>= 0.7.8, < 0.8.0)
     fluent-plugin-kubernetes_metadata_filter (2.0.0)
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-prometheus (1.2.1)
+    fluent-plugin-prometheus (1.4.0)
       fluentd (>= 0.14.20, < 2)
       prometheus-client
     fluent-plugin-remote_syslog_tls (1.0.2)
       fluentd
       remote_syslog_sender_tls (>= 1.2.5)
-    fluent-plugin-rewrite-tag-filter (2.1.1)
+    fluent-plugin-rewrite-tag-filter (2.2.0)
       fluent-config-regexp-type
       fluentd (>= 0.14.2, < 2)
-    fluent-plugin-splunk-enterprise (0.9.1)
+    fluent-plugin-splunk-enterprise (0.10.0)
       fluentd (>= 0.12.0)
       httpclient
       json
-    fluentd (1.3.3)
+    fluentd (1.6.2)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -73,7 +73,7 @@ GEM
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.5.3)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
     kubeclient (1.1.4)
@@ -85,15 +85,16 @@ GEM
     ltsv (0.1.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     minitest (5.11.3)
-    msgpack (1.2.6)
+    msgpack (1.3.0)
     multi_json (1.13.1)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     netrc (0.11.0)
+    oj (3.8.1)
     prometheus-client (0.9.0)
       quantile (~> 0.2.1)
-    public_suffix (3.0.3)
+    public_suffix (3.1.1)
     quantile (0.2.1)
     recursive-open-struct (1.0.0)
     remote_syslog_sender_tls (1.2.5)
@@ -102,9 +103,9 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    ruby-kafka (0.7.5)
+    ruby-kafka (0.7.9)
       digest-crc
-    serverengine (2.1.0)
+    serverengine (2.1.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
@@ -112,11 +113,11 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.9)
+    tzinfo-data (1.2019.2)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     yajl-ruby (1.4.1)
     zookeeper (1.4.11)
 
@@ -124,12 +125,18 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fluent-plugin-elasticsearch (~> 2.12.3)
-  fluent-plugin-kafka (~> 0.8.1)
+  cool.io
+  fluent-plugin-elasticsearch
+  fluent-plugin-kafka
   fluent-plugin-kubernetes_metadata_filter (~> 2.0.0)
-  fluent-plugin-prometheus (~> 1.2.1)
-  fluent-plugin-remote_syslog_tls (~> 1.0.2)
-  fluent-plugin-rewrite-tag-filter (~> 2.1.1)
-  fluent-plugin-splunk-enterprise (~> 0.9.1)
-  fluentd (~> 1.3.3)
-  zookeeper (~> 1.4.11)
+  fluent-plugin-prometheus
+  fluent-plugin-remote_syslog_tls
+  fluent-plugin-rewrite-tag-filter
+  fluent-plugin-splunk-enterprise
+  fluentd
+  json
+  oj
+  zookeeper
+
+BUNDLED WITH
+   2.0.2


### PR DESCRIPTION
Problem:
current elasticsearch gems has warning log for elasticsearch 7.x

Solution:
upgrade fluentd, elasticsearch etc gems version

Issue:
https://github.com/rancher/rancher/issues/20450
https://github.com/rancher/rancher/issues/20509